### PR TITLE
Add callback() post-push(obj)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function transform (obj, encoding, callback) {
   if (typeof obj != 'object') return callback("Expecting object, but got " + typeof obj);
   mail.send(obj);
   this.push(obj);
+  callback();
 }
 
 function flush (callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailgun-stream",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pipe messages to Mailgun",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using mailgun-stream, I found that multiple chunks pushed to the shared stream were not all getting processed by mailgun-stream. Only one was getting processed.

To demonstrate this, I created a test program. Once I made the change in the PR, the program sent both emails. I believe this is because the callback() on a transform stream is intended to be called when the tranform is done with the current chunk.

main.js

``` javascript
var mail     = require('mailgun-stream'),
    doublesend = require('./doublesend');

mail.config({key: 'mailgunkey'});

doublesend({
first : { subject: "subject1", body: "body1", recipient: "joe@email.com", sender: "bob@email.com"},
second : { subject: "subject2", body: "body2", recipient: "billy@email.com", sender: "billybob@email.com"}
}).pipe(mail.send());
```

doublesend.js

``` javascript
var thru = require('through2');

module.exports = function (obj) {
  var stream = thru.obj(transform, flush);
  if (obj) stream.write(obj);
  return stream;
};

function transform (obj, encoding, next) {
  this.push(obj.first);
  this.push(obj.second);
  next();
}

function flush (callback) {
  callback();
}
```
